### PR TITLE
Add `chain_from` function

### DIFF
--- a/doc/compositions.rst
+++ b/doc/compositions.rst
@@ -138,3 +138,45 @@ Compositions
     1       a
     2       b
     3       c
+
+.. function:: chain_from(gen, param, state)
+              iterator:chain_from()
+
+   :returns: a consecutive iterator for the chained contents of the subiterators
+
+   Turns an iterator over iterators into a chained iterator over all their
+   elements. It returns elements from the first iterator until it is
+   exhausted, then proceeds to the next iterator, until all of the iterators
+   are exhausted. Used for treating consecutive iterators as a single
+   iterator.
+
+   This is similar to :func:`chain` but retrieves the next subiterator only as
+   needed. Therefore, it is not required that the number of subiterators is
+   small or even finite.
+
+   Examples:
+
+   .. code-block:: lua
+
+    > each(print, chain_from({"abc", {"one", "two", "three"}}))
+    a
+    b
+    c
+    one
+    two
+    three
+
+    > each(print, chain_from(map(range, range(3))))
+    1
+    1
+    2
+    1
+    2
+    3
+
+    > each(print, take(5, chain_from(cycle({{"one", "two"}}))))
+    one
+    two
+    one
+    two
+    one

--- a/doc/compositions.rst
+++ b/doc/compositions.rst
@@ -180,3 +180,66 @@ Compositions
     one
     two
     one
+
+.. function:: bind(fun, gen, param, state)
+              iterator:bind(fun)
+
+   :param fun: is called for every element in the iterator
+   :type  fun: (function(...) -> iterator)
+   :returns: a new iterator
+
+   Return a new iterator by applying the **fun** to each element of
+   ``gen, param, state`` iterator and chaining the iterators returned by
+   **fun**. The mapping is performed on the fly and no values are buffered.
+
+   The function is equivalent to:
+
+   .. code-block:: lua
+
+    chain_from(map(fun, iter, gen, state))
+
+   It corresponds to the bind (``>>=``) operator of monads. In Haskell
+   notation its type would be written as: ``bind: (A -> [B]) -> [A] -> [B]``.
+
+   Examples:
+
+   .. code-block:: lua
+
+    > each(print, enumerate("abc"):bind(function(i, v) return
+        range(i):map(function(j) return
+          i, v, j
+        end)
+      end))
+    1 a 1
+    2 b 1
+    2 b 2
+    3 c 1
+    3 c 2
+    3 c 3
+
+    > each(print, iter{1,3,5}:bind(function(a) return
+        range(a):map(function(b) return
+          a*b
+        end)
+      end))
+    1
+    3
+    6
+    9
+    5
+    10
+    15
+    20
+    25
+
+   Corresponding to list comprehensions:
+
+   .. code-block:: python
+
+    [i, v, j
+     for i, v in enumerate("abc")
+     for j in range(i)]
+
+    [a*b
+     for a in {1, 3, 5}
+     for b in range(a)]

--- a/fun.lua
+++ b/fun.lua
@@ -1012,6 +1012,12 @@ end
 methods.chain_from = chain_from
 exports.chain_from = chain_from
 
+local bind = function(fun, gen, param, state)
+    return chain_from(map(fun, gen, param, state))
+end
+methods.bind = method1(bind)
+exports.bind = export1(bind)
+
 --------------------------------------------------------------------------------
 -- Operators
 --------------------------------------------------------------------------------

--- a/tests/compositions.lua
+++ b/tests/compositions.lua
@@ -168,3 +168,89 @@ dump(chain(range(0), range(1), range(0)))
 --[[test
 error: invalid iterator
 --test]]
+
+--------------------------------------------------------------------------------
+-- chain_from
+--------------------------------------------------------------------------------
+
+dump(chain_from{"abc"})
+--[[test
+a
+b
+c
+--test]]
+
+dump(chain_from{(range(2)), (range(3))})
+--[[test
+1
+2
+1
+2
+3
+--test]]
+
+dump(chain_from(map(range, range(3))))
+--[[test
+1
+1
+2
+1
+2
+3
+--test]]
+
+dump(take(15, cycle(chain_from{ (enumerate{"a", "b", "c"}),
+    {"one", "two", "three"} })))
+--[[test
+1 a
+2 b
+3 c
+one
+two
+three
+1 a
+2 b
+3 c
+one
+two
+three
+1 a
+2 b
+3 c
+--test]]
+
+local tab = {}
+local keys = {}
+for _it, k, v in chain_from{ { a = 11, b = 12, c = 13}, { d = 21, e = 22 } } do
+    tab[k] = v
+    table.insert(keys, k)
+end
+table.sort(keys)
+for _, key in ipairs(keys) do print(key, tab[key]) end
+--[[test
+a 11
+b 12
+c 13
+d 21
+e 22
+--test]]
+
+dump(chain_from{range(0), range(0), (range(0))})
+--[[test
+--test]]
+
+dump(chain_from{range(0), range(1), (range(2))})
+--[[test
+1
+1
+2
+--test]]
+
+dump(take(5, chain_from(cycle({{"one", "two"}}))))
+--[[test
+one
+two
+one
+two
+one
+--test]]

--- a/tests/compositions.lua
+++ b/tests/compositions.lua
@@ -254,3 +254,55 @@ one
 two
 one
 --test]]
+
+--------------------------------------------------------------------------------
+-- bind
+--------------------------------------------------------------------------------
+
+dump(range(3):bind(range))
+--[[test
+1
+1
+2
+1
+2
+3
+--test]]
+
+
+-- (i, v, j
+--  for i, v in enumerate("abc")
+--  for j in range(i))
+dump(enumerate("abc"):bind(function(i, v) return
+        range(i):map(function(j) return
+          i, v, j
+        end)
+      end))
+--[[test
+1 a 1
+2 b 1
+2 b 2
+3 c 1
+3 c 2
+3 c 3
+--test]]
+
+-- (a*b
+--  for a in {1, 3, 5}
+--  for b in range(a))
+dump(iter{1,3,5}:bind(function(a) return
+  range(a):map(function(b) return
+    a*b
+  end)
+end))
+--[[test
+1
+3
+6
+9
+5
+10
+15
+20
+25
+--test]]


### PR DESCRIPTION
Resolves #36.

Two comments:

- needed to add `setmetatable` in `deepcopy` to make it work for `chain_from`. This is not the only solution but can also be solved differently by using a function as state.
- I didn't know in which section best to put documentation/tests for `bind`
- I get if you don't like `bind` (or its name), in this case, you could just pick the first commit.