### PR TITLE
doc: build status markdown format tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Readable? Efficient? Can your Python/Ruby/V8 do better?
 Status
 ------
 
-**Lua Fun** is in an early alpha stage. The library fully [Documentation] and covered with unit tests.
+**Lua Fun** is in an early alpha stage. The library fully [documented][Documentation] and covered with unit tests.
 
 [![Build Status](https://travis-ci.org/luafun/luafun.png)](https://travis-ci.org/luafun/luafun)
 
@@ -67,7 +67,7 @@ notice. Please use **stable** branch for your production deployments.
 If you still want to use **master**, please don't forget to grep `git log`
 for *Incompatible API changes* message. Thanks!
 
-Please check out [Documentation] for more information.
+Please check out [documentation][Documentation] for more information.
 
 Misc
 ----

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Status
 **Lua Fun** is in an early alpha stage. The library fully [documented]
 [Documentation] and covered with unit tests.
 
-[![Build Status](https://travis-ci.org/luafun/luafun.png)]
-(https://travis-ci.org/luafun/luafun)
+[![Build Status](https://travis-ci.org/luafun/luafun.png)](https://travis-ci.org/luafun/luafun)
 
 LuaJIT 2.1 alpha is recommended. The library designed in mind of fact that
 [LuaJIT traces tail-, up- and down-recursion][LuaJIT-Recursion] and has a lot of

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Readable? Efficient? Can your Python/Ruby/V8 do better?
 Status
 ------
 
-**Lua Fun** is in an early alpha stage. The library fully [documented]
-[Documentation] and covered with unit tests.
+**Lua Fun** is in an early alpha stage. The library fully [Documentation] and covered with unit tests.
 
 [![Build Status](https://travis-ci.org/luafun/luafun.png)](https://travis-ci.org/luafun/luafun)
 
@@ -68,7 +67,7 @@ notice. Please use **stable** branch for your production deployments.
 If you still want to use **master**, please don't forget to grep `git log`
 for *Incompatible API changes* message. Thanks!
 
-Please check out [documentation][Documentation] for more information.
+Please check out [Documentation] for more information.
 
 Misc
 ----


### PR DESCRIPTION
now the build status is broken as the following:
![screen shot 2017-05-26 at 18 10 04](https://cloud.githubusercontent.com/assets/3370345/26490591/91bf3ab0-423e-11e7-9287-0dd3d3c64c49.png)

Also "Document"
![screen shot 2017-05-26 at 18 15 45](https://cloud.githubusercontent.com/assets/3370345/26490799/6563faea-423f-11e7-8780-e1080f75c6d9.png)
