### PR TITLE
Add `riter` reverse iterator function

### DIFF
--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -399,3 +399,10 @@ for _it, a in riter(iter(riter({}))) do print(a) end
 for _it, a in wrap(wrap(riter({}))) do print(a) end
 --[[test
 --test]]
+
+for _, a in ipairs(riter({1, 2, 3}):totable()) do print(a) end
+--[[test
+3
+2
+1
+--test]]

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -330,3 +330,72 @@ d
 e
 f
 --test]]
+
+for _it, a in riter({1, 2, 3}) do print(a) end
+--[[test
+3
+2
+1
+--test]]
+
+for _it, a in riter("abcdef") do print(a) end
+--[[test
+f
+e
+d
+c
+b
+a
+--test]]
+
+for _it, a in riter(riter("abcdef")) do print(a) end
+--[[test
+a
+b
+c
+d
+e
+f
+--test]]
+
+for _it, a in riter("a") do print(a) end
+--[[test
+a
+--test]]
+
+for _it, a in riter("") do print(a) end
+--[[test
+--test]]
+
+for _it, a in iter(iter(riter({1, 2, 3}))) do print(a) end
+--[[test
+3
+2
+1
+--test]]
+
+for _it, a in riter(iter(riter({1, 2, 3}))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(riter({1, 2, 3}))) do print(a) end
+--[[test
+3
+2
+1
+--test]]
+
+for _it, a in riter({}) do print(a) end
+--[[test
+--test]]
+
+for _it, a in riter(iter(riter({}))) do print(a) end
+--[[test
+--test]]
+
+for _it, a in wrap(wrap(riter({}))) do print(a) end
+--[[test
+--test]]


### PR DESCRIPTION
This PR adds `riter` function which iterates collection in reverse order. For many cases reverse iteration doesn't have any sense (iterating maps) or simply will not work (infinite cycles), so this function should be used carefully. Internally the implementation is optimized for plain arrays and strings, in which case it performs very nicely. For all other cases (iterator triplets/iterator objects) it does naive fallback: collects data in plain table and runs optimized version with this table.

Some examples
```lua
require('fun')()
-- reverse an array
local reversed = riter{1,2,3,4}:totable() -- yields {4,3,2,1}
-- fold right
local folded = riter{'H','e','l','l','o'}:reduce( operator.concat, '' ) -- yields 'olleH'
```

Also added tests.