### PR TITLE
doc/under_the_hood: various typographical and grammatical improvements

### DIFF
--- a/doc/under_the_hood.rst
+++ b/doc/under_the_hood.rst
@@ -3,7 +3,7 @@ Under the Hood
 
 .. module:: fun
 
-The section shed some light on the internal library structure and working
+This section sheds some light on the internal library structure and working
 principles.
 
 Iterators
@@ -34,12 +34,12 @@ Let's see how each value is used for:
 
 ``param`` -- second value
    A permanent (constant) parameter of a generating function is used to create
-   specific instance of the generating function. For example, a table itself
-   for ``ipairs`` case.
+   a specific instance of the generating function. For example, a table itself
+   for this ``ipairs`` case.
 
 ``state`` -- third value
-   A some transient state of an iterator that is changed after each iteration.
-   For example, an array index for ``ipairs`` case.
+   A transient state of an iterator that is changed after each iteration. For
+   example, an array index for this ``ipairs`` case.
 
 Try to call ``gen`` function manually:
 
@@ -49,13 +49,13 @@ Try to call ``gen`` function manually:
     > =gen(param, state)
     1       a
 
-The ``gen`` function returned a new state ``1`` and the next iteration
-value ``a``. The second call to ``gen`` with the new state will return the next
-state  and the next iteration value. When the iterator finishes to the end
-the ``nil`` value is returned instead of the next state.
+The ``gen`` function returned a new state ``1`` and the next iteration value
+``a``. The second call to ``gen`` with the new state will return the next state
+and the next iteration value. When the iterator finishes to the end, the ``nil``
+value is returned instead of the next state.
 
-**Please do not panic!** You do not have to use these values directly.
-It is just a nice trick to get ``for .. in`` loop working in Lua.
+**Please do not panic!** You do not have to use these values directly. It is
+just a nice trick to get ``for .. in`` loop working in Lua.
 
 Iterations
 ----------
@@ -83,17 +83,16 @@ According to Lua reference manual [#lua_for]_ the code above is equivalent to::
 
 What does it mean for us?
 
-* An iterator can be used together with ``for .. in`` to generate a loop
-* An iterator is fully defined using ``gen``, ``param`` and ``state`` iterator
-  triplet
-* The ``nil`` state marks the end of an iteration
-* An iterator can return an arbitrary number of values (multireturn)
-* It is possible to make some wrapping functions to take an iterator and
+* An iterator can be used together with ``for .. in`` to generate a loop.
+* An iterator is fully defined using the ``gen``, ``param`` and ``state``
+  iterator triplet.
+* The ``nil`` state marks the end of an iteration.
+* An iterator can return an arbitrary number of values (multireturn).
+* It is possible to make some wrapping functions to take an iterator and return
+  a new modified iterator.
 
-  return a new modified iterator
-
-**The library provides a set of iterators** that can be used like ``pairs``
-and ``ipairs``.
+**The library provides a set of iterators** that can be used like ``pairs`` and
+``ipairs``.
 
 Iterator Types
 --------------
@@ -101,29 +100,27 @@ Iterator Types
 Pure functional iterators
 `````````````````````````
 
-Iterators can be either pure functional or have some side effects and returns
+Iterators can be either pure functional or have some side effects and return
 different values for some initial conditions [#pure_function]_. An **iterator is
 pure functional** if it meets the following criteria:
 
 - ``gen`` function always returns the same values for the same ``param`` and
-  ``state`` values (idempotence property)
+  ``state`` values (idempotence property).
 - ``param`` and ``state`` values are not modified during ``gen`` call and
   a new ``state`` object is returned instead (referential transparency
   property).
 
-Pure functional iterators are very important for us. Pure functional iterator
-can be safety cloned or reapplied without creating side effects. Many library
-function use these properties.
+Pure functional iterators are very important for us. Pure functional iterators
+can be safely cloned or reapplied without creating side effects. Many library
+functions use these properties.
 
 Finite iterators
 ````````````````
 
-Iterators can be **finite** (sooner or later end up) or **infinite**
-(never end).
-Since there is no way to determine automatically if an iterator is finite or
-not [#turing]_ the library function can not automatically resolve infinite
-loops. It is your obligation to do not pass infinite iterator to reducing
-functions.
+Iterators can be **finite** (end sooner or later) or **infinite** (never end).
+Since there is no way to automatically determine if an iterator is finite or not
+[#turing]_, the library function cannot automatically resolve infinite loops. It
+is your obligation to not pass an infinite iterator to reducing functions.
 
 Tracing JIT
 -----------
@@ -131,7 +128,7 @@ Tracing JIT
 Tracing just-in-time compilation is a technique used by virtual machines to
 optimize the execution of a program at runtime. This is done by recording a
 linear sequence of frequently executed operations, compiling them to native
-machine code and executing them.
+machine code, and executing them.
 
 First profiling information for loops is collected. After a hot loop has been
 identified, a special tracing mode is entered which records all executed
@@ -140,10 +137,10 @@ The trace is then optimized and compiled to machine code (trace). When this
 loop is executed again the compiled trace is called instead of the program
 counterpart [#tracing_jit]_.
 
-Why the tracing JIT is important for us? The LuaJIT tracing compiler can detect
+Why is the tracing JIT important for us? The LuaJIT tracing compiler can detect
 tail-, up- and down-recursion [#luajit-recursion]_, unroll compositions of
-functions and inline high-order functions [#luajit-optimizations]_.
-All of these concepts make the foundation for functional programming.
+functions and inline high-order functions [#luajit-optimizations]_. All of these
+concepts make the foundation for functional programming.
 
 .. [#iterators] http://en.wikipedia.org/wiki/Turtles_all_the_way_down
 .. [#lua_for] http://www.lua.org/manual/5.2/manual.html#3.3.5


### PR DESCRIPTION
This PR is just a collection of various documentation improvements to the "Under the Hood" page as the title says. 🙂

I think the page is pretty much already fine as is :+1:. So I don't mind if you don't want these changes, it's just some superficial improvements really.

In addition to the grammar stuff, the typographical changes include:

- Typo fixes (`safety` -> `safely`, `can not` -> `cannot`)
- Some list items had a period, others did not, so I put periods at the end of all of them to make it consistent.
- Remove multiple whitespace between words.

In addition I made sure that these changes remained wrapped at 80 columns. Don't hesitate to request any changes if there's any particular things you do not like or if I made any mistakes. :wink: