### PR TITLE
pairs & map_pairs generators, with_key & index_by transformers

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -844,6 +844,43 @@ end
 methods.enumerate = method0(enumerate)
 exports.enumerate = export0(enumerate)
 
+local with_key_gen_call = function(new_state, ...)
+    if new_state == nil then
+        return nil
+    end
+    return new_state, new_state, ...
+end
+
+local with_key_gen = function(param, state)
+    local gen_x, param_x = param[1], param[2]
+    return with_key_gen_call(gen_x(param_x, state))
+end
+
+local with_key = function(gen, param, state)
+    return wrap(with_key_gen, {gen, param}, state)
+end
+methods.with_key = method0(with_key)
+exports.with_key = export0(with_key)
+
+local index_by_gen_call = function(fn, new_state, ...)
+    if new_state == nil then
+        return nil
+    end
+    local key = fn(...)
+    return new_state, key, ...
+end
+
+local index_by_gen = function(param, state)
+    local fn, gen_x, param_x = param[1], param[2], param[3]
+    return index_by_gen_call(fn, gen_x(param_x, state))
+end
+
+local index_by = function(fn, gen, param, state)
+    return wrap(index_by_gen, {fn, gen, param}, state)
+end
+methods.index_by = method1(index_by)
+exports.index_by = export1(index_by)
+
 local intersperse_call = function(i, state_x, ...)
     if state_x == nil then
         return nil

--- a/fun.lua
+++ b/fun.lua
@@ -133,6 +133,16 @@ local iter = function(obj, param, state)
 end
 exports.iter = iter
 
+local iter_pairs = function(obj)
+    return wrap(pairs(obj))
+end
+exports.pairs = iter_pairs
+
+local iter_map_pairs = function(obj)
+    return wrap(kv_iter_gen, obj, nil)
+end
+exports.map_pairs = iter_map_pairs
+
 local method0 = function(fun)
     return function(self)
         return fun(self.gen, self.param, self.state)

--- a/fun.lua
+++ b/fun.lua
@@ -90,9 +90,9 @@ end
 local ipairs_gen = ipairs({}) -- get the generating function from ipairs
 
 local pairs_gen = pairs({ a = 0 }) -- get the generating function from pairs
-local map_gen = function(tab, key)
+local kv_iter_gen = function(tab, key)
     local value
-    local key, value = pairs_gen(tab, key)
+    key, value = pairs_gen(tab, key)
     return key, key, value
 end
 
@@ -114,7 +114,7 @@ local rawiter = function(obj, param, state)
             return ipairs(obj)
         else
             -- hash
-            return map_gen, obj, nil
+            return kv_iter_gen, obj, nil
         end
     elseif (type(obj) == "function") then
         return obj, param, state

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -53,7 +53,7 @@ for _it, a in wrap(wrap(ipairs({}))) do print(a) end
 -- Check that ``iter`` for arrays is equivalent to ``ipairs``
 local t = {1, 2, 3}
 gen1, param1, state1 = iter(t):unwrap()
-gen2, param2, state2 = ipairs(t) 
+gen2, param2, state2 = ipairs(t)
 print(gen1 == gen2, param1 == param2, state1 == state2)
 --[[test
 true true true
@@ -170,6 +170,48 @@ error: object 1 of type "number" is not iterable
 for _it, a in iter(1, 2, 3, 4, 5, 6, 7) do print(a) end
 --[[test
 error: object 1 of type "number" is not iterable
+--test]]
+
+--------------------------------------------------------------------------------
+-- pairs
+--------------------------------------------------------------------------------
+
+for _it, a in fun.pairs({4, 5, 6}) do print(a) end
+--[[test
+4
+5
+6
+--test]]
+
+local t = {}
+for _it, v in fun.pairs({a = 4, b = 5, c = 6}) do t[#t + 1] = v end
+table.sort(t)
+for _it, v in iter(t) do print(v) end
+--[[test
+4
+5
+6
+--test]]
+
+--------------------------------------------------------------------------------
+-- map_pairs
+--------------------------------------------------------------------------------
+
+each(function(k, v) print(k, v) end, map_pairs({4, 5, 6}))
+--[[test
+1 4
+2 5
+3 6
+--test]]
+
+local t = {}
+each(function(k, v) t[#t + 1] = {k, v} end, map_pairs({a = 4, b = 5, c = 6}))
+table.sort(t, function(a, b) return a[1] < b[1] end)
+for _it, v in iter(t) do print(v[1], v[2]) end
+--[[test
+a 4
+b 5
+c 6
 --test]]
 
 --------------------------------------------------------------------------------

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -372,3 +372,23 @@ d
 e
 f
 --test]]
+
+
+--------------------------------------------------------------------------------
+-- index_by
+--------------------------------------------------------------------------------
+
+local a = string.byte('a')
+local tab = tomap(index_by(function(x, y) return x[1] .. '!' end,
+    iter({{'a', 4}, {'b', 5}, {'c', 6}})))
+print(type(tab), #tab)
+local t = {}
+for _it, k, v in iter(tab) do t[#t + 1] = {k, v[1], v[2]} end
+table.sort(t, function(a, b) return a[1] < b[1] end)
+for _, v in pairs(t) do print(v[1], v[2], v[3]) end
+--[[test
+table 0
+a! a 4
+b! b 5
+c! c 6
+--test]]

--- a/tests/runtest
+++ b/tests/runtest
@@ -1,7 +1,8 @@
 #!/usr/bin/env lua
 
 package.path = "../?.lua;"..package.path
-require "fun" ()
+fun = require "fun"
+fun()
 function dump(gen, init, state) each(print, gen, init, state) end
 
 local unpack = rawget(table, "unpack") or unpack


### PR DESCRIPTION
Using `iter` is dangerous on sparse arrays: it produces completely different generators based on `#obj > 0` condition, while the result of this condition is unpredictable for sparse arrays in lua.

Also `iter` is the only way to create map-generator, which passes key and value to filter/transform function. But it's works wrong when input value appears to have integer keys: in unpredictable way `iter` can return array-iterator or map-iterator.

This PR introduces `fun.pairs` and `fun.map_pairs` functions to create generators in explicit way. Both works the same way as `fun.iter(pairs(...))` but the second one returns map-generator.

Additional `with_key`, `index_by` methods take any generator and return map-generator for it. `with_key` uses `state` as key value which works fine for the most cases, and `index_by` takes function to generate key value with. This makes it possible to generate map from table with luafun only:

```lua
input = {{'a', 1}, {'b', 2}}

fun.iter(input):with_key():map(function(_, v) return v[1], v[2] end):tomap()
-- > {a = 1, b = 2}
fun.iter(input):index_by(function(v) return v[1] end):tomap()
-- > {a = {'a', 1}, b = {'b', 2}}
```