### PR TITLE
Make it work after github removed git:// support

### DIFF
--- a/fun-scm-1.rockspec
+++ b/fun-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "fun"
 version = "scm-1"
 
 source = {
-    url = "git://github.com/luafun/luafun.git",
+    url = "git+https://github.com/luafun/luafun.git",
 }
 
 description = {


### PR DESCRIPTION
Due to: https://github.blog/2021-09-01-improving-git-protocol-security-github/ the rockspec no longer works. 