### PR TITLE
readme: fix links parsing and use https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@ even Lisp. High-order functions such as ``map``, ``filter``, ``reduce``,
 
 Let's see an example:
 
-    > -- Functional style
-    > require "fun" ()
-    > -- calculate sum(x for x^2 in 1..n)
-    > n = 100
-    > print(reduce(operator.add, 0, map(function(x) return x^2 end, range(n))))
-    328350
+```lua
+> -- Functional style
+> require "fun" ()
+> -- calculate sum(x for x^2 in 1..n)
+> n = 100
+> print(reduce(operator.add, 0, map(function(x) return x^2 end, range(n))))
+328350
 
-    > -- Object-oriented style
-    > local fun = require "fun"
-    > -- calculate sum(x for x^2 in 1..n)
-    > print(fun.range(n):map(function(x) return x^2 end):reduce(operator.add, 0))
-    328350
+> -- Object-oriented style
+> local fun = require "fun"
+> -- calculate sum(x for x^2 in 1..n)
+> print(fun.range(n):map(function(x) return x^2 end):reduce(operator.add, 0))
+328350
+```
 
 **Lua Fun** takes full advantage of the innovative **tracing JIT compiler**
 to achieve transcendental performance on nested functional expressions.
@@ -32,18 +34,20 @@ Functional compositions and high-order functions can be translated into
 **efficient machine code**. Can you believe it? Just try to run the example
 above with ``luajit -jdump`` and see what happens:
 
-    -- skip some initilization code --
-    ->LOOP:
-    0bcaffd0  movaps xmm5, xmm7
-    0bcaffd3  movaps xmm7, xmm1
-    0bcaffd6  addsd xmm7, xmm5
-    0bcaffda  ucomisd xmm7, xmm0
-    0bcaffde  jnb 0x0bca0024        ->5
-    0bcaffe4  movaps xmm5, xmm7
-    0bcaffe7  mulsd xmm5, xmm5
-    0bcaffeb  addsd xmm6, xmm5
-    0bcaffef  jmp 0x0bcaffd0        ->LOOP
-    ---- TRACE 1 stop -> loop
+```asm
+-- skip some initilization code --
+->LOOP:
+0bcaffd0  movaps xmm5, xmm7
+0bcaffd3  movaps xmm7, xmm1
+0bcaffd6  addsd xmm7, xmm5
+0bcaffda  ucomisd xmm7, xmm0
+0bcaffde  jnb 0x0bca0024        ->5
+0bcaffe4  movaps xmm5, xmm7
+0bcaffe7  mulsd xmm5, xmm5
+0bcaffeb  addsd xmm6, xmm5
+0bcaffef  jmp 0x0bcaffd0        ->LOOP
+---- TRACE 1 stop -> loop
+```
 
 The functional chain above was translated by LuaJIT to (!) **one machine loop**
 containing just 10 CPU assembly instructions without CALL. Unbelievable!

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ See Also
 * luajit@freelists.org
 * roman@tsisyk.com
 
- [Lua]: http://www.lua.org/
- [LuaJIT]: http://luajit.org/luajit.html
+ [Lua]: https://www.lua.org/
+ [LuaJIT]: https://luajit.org/luajit.html
  [LuaJIT-Recursion]: http://lambda-the-ultimate.org/node/3851#comment-57679
  [LuaJIT-Optimizations]: http://wiki.luajit.org/Optimizations
- [MIT/X11 License]: http://opensource.org/licenses/MIT
- [Tarantool]: http://github.com/tarantool/tarantool
+ [MIT/X11 License]: https://opensource.org/licenses/MIT
+ [Tarantool]: https://github.com/tarantool/tarantool
  [Getting Started]: https://luafun.github.io/getting_started.html
- [Documentation]: http://luafun.github.io/
+ [Documentation]: https://luafun.github.io/
  [Travis]: https://travis-ci.org/luafun/luafun
  [RockSpec]: https://raw.github.com/luafun/luafun/master/fun-scm-1.rockspec
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ Readable? Efficient? Can your Python/Ruby/V8 do better?
 Status
 ------
 
-**Lua Fun** is in an early alpha stage. The library fully [documented]
-[Documentation] and covered with unit tests.
+**Lua Fun** is in an early alpha stage. The library fully
+[documented][Documentation] and covered with unit tests.
 
-[![Build Status](https://travis-ci.org/luafun/luafun.png)]
-(https://travis-ci.org/luafun/luafun)
+[![Build Status](https://travis-ci.org/luafun/luafun.png)][Travis]
 
 LuaJIT 2.1 alpha is recommended. The library designed in mind of fact that
 [LuaJIT traces tail-, up- and down-recursion][LuaJIT-Recursion] and has a lot of
@@ -98,6 +97,7 @@ See Also
  [Tarantool]: http://github.com/tarantool/tarantool
  [Getting Started]: https://luafun.github.io/getting_started.html
  [Documentation]: http://luafun.github.io/
+ [Travis]: https://travis-ci.org/luafun/luafun
  [RockSpec]: https://raw.github.com/luafun/luafun/master/fun-scm-1.rockspec
 
 Please **"Star"** the project on GitHub to help it to survive! Thanks!


### PR DESCRIPTION
* Fixed markdown syntax around links.
* Used `https://` for links where possible.
* Enable syntax highlighting for code snippets.

Supersedes #38
Supersedes #43