### PR TITLE
adds index operators

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -1026,6 +1026,12 @@ local operator = {
     lor = function(a, b) return a or b end,
     lnot = function(a) return not a end,
     truth = function(a) return not not a end,
+    ----------------------------------------------------------------------------
+    -- Index operators
+    ----------------------------------------------------------------------------    
+    first = function(a) return a end,
+    second = function(_, a) return a end,
+    index = function(fname) return function(t) return t[fname] end end,
 }
 exports.operator = operator
 methods.operator = operator


### PR DESCRIPTION
Sometimes in Tarantool console or somewhere else we need to index elements from iterator.
Some of the examples from Tarantool:

```
-- Sums memory usage
fun.iter(box.info.memory()):map(function(key, value) return value end):sum()

-- Get list of fibers
fun.iter(fiber.info()):map(function(id, fiber) return fiber end):totable()

-- get some field
box.space.users:pairs():map(function(tuple) return tuple.ctime end):max()
```

Adding this operators we may ease code:

```
fun.iter(box.info.memory()):map(fun.op.second):sum()

fun.iter(fiber.info()):map(fun.op.second):totable()

box.space.users:pairs():map(fun.op.index "ctime"):max()
```

Using this combination we may even grep by pattern and return only necessary fields:

```
fun.iter(box.space):grep("^%d+$"):map(fun.op.second):map(fun.op.index "engine"):totable()
```