### PR TITLE
chain: don't stop on param = nil

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -943,7 +943,7 @@ local chain_gen_r2 = function(param, state, state_x, ...)
     if state_x == nil then
         local i = state[1]
         i = i + 1
-        if param[3 * i - 1] == nil then
+        if param[3 * i - 2] == nil then
             return nil
         end
         local state_x = param[3 * i]

--- a/tests/compositions.lua
+++ b/tests/compositions.lua
@@ -168,3 +168,33 @@ dump(chain(range(0), range(1), range(0)))
 --[[test
 error: invalid iterator
 --test]]
+
+-- Similar to fun.range(), but accepts just 'stop' for simplicity.
+--
+-- The key point of this iterator generator is that it doesn't use
+-- 'param' (the second value in the gen-param-state triplet) and
+-- pass nil to it. This is needed to reproduce the next scenario.
+function myrange(stop)
+    local function gen(_param, i)
+        if i < stop then
+            return i + 1, i + 1
+        end
+        return nil
+    end
+    return wrap(gen, nil, 0)
+end
+
+-- gh-86: verify that chain don't stop on an iterator that uses
+-- param = nil.
+dump(chain(myrange(3), myrange(3), myrange(3)))
+--[[test
+1
+2
+3
+1
+2
+3
+1
+2
+3
+--test]]


### PR DESCRIPTION
The implementation of the `chain` function saves the gen-param-state triplets for all the source iterators into a table and tracks an index in this table to know, which source iterator is the current one.

When the current iterator is exhausted, `chain`'s gen function checks the source iterators table: is there a next source iterator?

The problem is that it checks `param` against `nil`, however it would be more natural and correct to check `gen` against `nil`.

This commit fixes the condition, so now `chain` works for iterators that don't use `param` at all.

Fixes #86